### PR TITLE
refactor output format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.12
+FROM python:3.10.13
 
 WORKDIR /processor
 
@@ -10,4 +10,4 @@ RUN pip install -r /processor/requirements.txt
 
 COPY processor/ /processor
 
-CMD ["python3.9", "/processor/main.py" ]
+CMD ["python3.10", "/processor/main.py" ]

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM python:3.9.12
+FROM python:3.10.13
 
 WORKDIR /
 

--- a/processor/base_processor/timeseries/base.py
+++ b/processor/base_processor/timeseries/base.py
@@ -324,15 +324,8 @@ def discontinuous_chunks(timestamps, sampling_rate):
     boundaries = np.concatenate(
         ([0], np.where( np.diff(timestamps) > gap_threshold)[0] + 1, [len(timestamps)]))
 
-    if (len(boundaries) > 2):
-        print(len(boundaries))
-        print(np.diff(timestamps))
-        print(gap_threshold)
-
     for i in np.arange(len(boundaries)-1):
         start_index = boundaries[i]
-        # print(type(start_index))
-        # print(start_index)
         end_index = boundaries[i + 1] - 1
 
         start_time = timestamps[start_index]

--- a/processor/base_processor/timeseries/base.py
+++ b/processor/base_processor/timeseries/base.py
@@ -256,13 +256,20 @@ class BaseTimeSeriesProcessor(BaseProcessor):
 
     def write_channel_data(self, channel, timestamps, values):
         """
-        Write channel data. Updates start/end times of channel object as necessary.
+        Write channel data to binary file.
+
+        Updates channel contiguous_chunks metadata.
+
+        Updates start/end times of channel object as necessary.
 
         NOTE: timestamps and values are assumed to be in chronological order!
         """
         # append serialized sample data to file
         with open(channel.data_file,'ab') as f:
             f.write(values.tobytes())
+
+        for chunk in discontinuous_chunks(timestamps, channel.rate):
+            channel.add_nonoverlapping_contiguous_chunk(chunk)
 
         # update start/end times
         start_time = int(utils.infer_epoch(timestamps[0]))

--- a/processor/base_processor/timeseries/base.py
+++ b/processor/base_processor/timeseries/base.py
@@ -1,3 +1,4 @@
+import bisect
 import os
 import datetime
 import numpy as np
@@ -20,6 +21,9 @@ class TimeSeriesChannel(object):
         self.group    = group
         self.last_annot = 0
         self.properties = []
+
+        # stores starting timestamp/index markers for contiguous data within the channel
+        self.contiguous_chunks = []
 
         # metadata
         self.index      = index
@@ -45,6 +49,7 @@ class TimeSeriesChannel(object):
             'type':  self.type,
             'group': self.group,
             'lastAnnotation': self.last_annot,
+            'contiguousChunks': [c.as_dict() for c in self.contiguous_chunks],
             'properties': self.properties
         }
         if self.id is not None:
@@ -66,9 +71,20 @@ class TimeSeriesChannel(object):
         ch.start      = d['start']
         ch.end        = d['end']
         ch.last_annot = d['lastAnnotation']
+        ch.contiguous_chunks = TimeSeriesContiguousChunk.from_dict(d['contiguousChunks'])
         ch.properties = d['properties']
 
         return ch
+
+    def add_nonoverlapping_contiguous_chunk(self, chunk):
+        # find the leftmost insertion point into the ordered list of contiguous_chunks
+        i = bisect.bisect_left(self.contiguous_chunks, chunk.start, key=lambda c: c.start)
+
+        # ensure the new chunk doesn't overlap with another chunk
+        assert i == 0 or chunk.start > self.contiguous_chunks[i - 1].end
+        assert i == len(self.contiguous_chunks) or chunk.end < self.contiguous_chunks[i].start
+
+        self.contiguous_chunks.insert(i, chunk)
 
 
 class TimeSeriesSpike(object):
@@ -242,16 +258,11 @@ class BaseTimeSeriesProcessor(BaseProcessor):
         """
         Write channel data. Updates start/end times of channel object as necessary.
 
-        NOTE: timestamps/values are assumed to be in chronological order!
+        NOTE: timestamps and values are assumed to be in chronological order!
         """
-        # save as ts/value pairs: [ts1, val1, ts2, val2, ...]
-        interleaved = np.empty((timestamps.size + values.size), dtype=np.float64)
-        interleaved[0::2] = timestamps
-        interleaved[1::2] = values
-
-        # append serialized interleaved data to file
+        # append serialized sample data to file
         with open(channel.data_file,'ab') as f:
-            f.write(interleaved.tobytes())
+            f.write(values.tobytes())
 
         # update start/end times
         start_time = int(utils.infer_epoch(timestamps[0]))
@@ -266,6 +277,62 @@ class BaseTimeSeriesProcessor(BaseProcessor):
 
         # replace with updated
         self.channels[channel.index] = channel
+
+
+class TimeSeriesContiguousChunk:
+    '''
+    Attributes:
+        index: index at which the contiguous chunk starts
+        start: starting timestamp for the contiguous chunk
+        end: ending timestamp for the contiguous chunk
+    '''
+    def __init__(self, index, start, end):
+        assert end >= start, "contiguous chunk should not have an ending timestamp less than its starting timestamp"
+
+        self.index = index
+        self.start = utils.infer_epoch(start)
+        self.end = utils.infer_epoch(end)
+
+    def as_dict(self):
+        return {
+            'index': int(self.index),
+            'start': self.start,
+            'end':   self.end,
+        }
+
+    @classmethod
+    def from_dict(cls, d):
+        return cls(index = d['index'], start = d['start'], end = d['end'])
+
+def discontinuous_chunks(timestamps, sampling_rate):
+    '''
+    Returns the index ranges for contiguous segments in data.
+    Boundaries are identified as follows:
+
+        (timestamp difference) > 2 * (sampling period)
+
+    '''
+    gap_threshold = (1.0/sampling_rate)*1e6 * 2
+
+    boundaries = np.concatenate(
+        ([0], np.where( np.diff(timestamps) > gap_threshold)[0] + 1, [len(timestamps)]))
+
+    if (len(boundaries) > 2):
+        print(len(boundaries))
+        print(np.diff(timestamps))
+        print(gap_threshold)
+
+    for i in np.arange(len(boundaries)-1):
+        start_index = boundaries[i]
+        # print(type(start_index))
+        # print(start_index)
+        end_index = boundaries[i + 1] - 1
+
+        start_time = timestamps[start_index]
+        end_time = timestamps[end_index]
+
+        yield TimeSeriesContiguousChunk(index = int(start_index), start = start_time, end = end_time)
+
 
 class TimeSeriesChunk:
     '''

--- a/processor/base_processor/timeseries/base.py
+++ b/processor/base_processor/timeseries/base.py
@@ -304,7 +304,7 @@ class TimeSeriesContiguousChunk:
         return {
             'index': int(self.index),
             'start': self.start,
-            'end':   self.end,
+            # 'end':   self.end, # end index not required for channel metadata output
         }
 
     @classmethod
@@ -313,13 +313,13 @@ class TimeSeriesContiguousChunk:
 
 def discontinuous_chunks(timestamps, sampling_rate):
     '''
-    Returns the index ranges for contiguous segments in data.
+    Returns contiguous segments (chunks) in data.
     Boundaries are identified as follows:
 
         (timestamp difference) > 2 * (sampling period)
 
     '''
-    gap_threshold = (1.0/sampling_rate)*1e6 * 2
+    gap_threshold = utils.secs_to_usecs(1.0/sampling_rate) * 2
 
     boundaries = np.concatenate(
         ([0], np.where( np.diff(timestamps) > gap_threshold)[0] + 1, [len(timestamps)]))

--- a/processor/base_processor/timeseries/tests.py
+++ b/processor/base_processor/timeseries/tests.py
@@ -105,7 +105,7 @@ def number_samples_test(task, expected):
         for channel in task.channels:
             num_bytes = os.stat(channel.data_file).st_size
             # interleaved values/timestamps at 8 bytes each
-            nsamples  = num_bytes / 16
+            nsamples  = num_bytes / 8
             try:
                 # channel-specific sample size
                 exp_chan = expected.channels[str(channel.name)]
@@ -156,8 +156,7 @@ def sin_wave_test(task, expected):
     # one channel is "Sin 10Hz" and the other is "Sin 20Hz"
     # because of the transformation and encoding of the different file format, we allow for a 1% difference in value
     for channel in task.channels:
-        data = np.fromfile(channel.data_file, dtype=CONTINUOUS_TYPE)
-        file_values = data['value'].astype(np.float64)
+        file_values = np.fromfile(channel.data_file, dtype=np.float64)
         template_values = []
         try:
             rate = expected.channels[str(channel.name)].rate
@@ -182,7 +181,7 @@ def channels_test(task, ts_test):
     result_files = glob.glob('*ts.bin')
     assert len(task.channels) == len(result_files)
 
-    bin_test(task, result_files)
+    # bin_test(task, result_files)
 
     # cleanup
     [os.remove(f) for f in result_files]

--- a/processor/base_processor/timeseries/tests.py
+++ b/processor/base_processor/timeseries/tests.py
@@ -4,11 +4,6 @@ import pytest
 import math
 import numpy as np
 
-CONTINUOUS_TYPE = np.dtype([
-    ('timestamp',  np.float64),
-    ('value',      np.float64),
-])
-
 # ------------------- test models -------------------
 
 class ChannelTest(object):
@@ -72,7 +67,6 @@ class TimeSeriesTest(object):
 
 def inferred_rate_test(channel):
     if channel.type == 'CONTINUOUS':
-        data = np.fromfile(channel.data_file, dtype=np.float64)
         inferred_rate = float(channel.num_values)/((channel.end-channel.start)/1e6)
 
         assert channel.rate == pytest.approx(inferred_rate, 0.01)

--- a/processor/base_processor/timeseries/tests.py
+++ b/processor/base_processor/timeseries/tests.py
@@ -70,15 +70,12 @@ class TimeSeriesTest(object):
 
 # ------------------- helper methods -------------------
 
-def inferred_rate_test(rate, fname, ftype='CONTINUOUS'):
-    if ftype == 'CONTINUOUS':
-        data = np.fromfile(fname, dtype=CONTINUOUS_TYPE, count=22)
-        filesize = min(len(data['timestamp']),22)
-        #We infer the rate from two non consecutive timestamps to account for rounding errors
-        d1 = data['timestamp'][1].astype(np.int64)
-        d2 = data['timestamp'][filesize-1].astype(np.int64)
-        inferred_rate = 1e6/((d2-d1)/float(filesize-2))
-        assert rate == pytest.approx(inferred_rate, 0.01)
+def inferred_rate_test(channel):
+    if channel.type == 'CONTINUOUS':
+        data = np.fromfile(channel.data_file, dtype=np.float64)
+        inferred_rate = float(channel.num_values)/((channel.end-channel.start)/1e6)
+
+        assert channel.rate == pytest.approx(inferred_rate, 0.01)
 
 def sin_wav(t,amp,frequency):
     return amp * math.sin( 2 * math.pi * frequency * t)
@@ -104,7 +101,6 @@ def number_samples_test(task, expected):
     if not expected.spikes:
         for channel in task.channels:
             num_bytes = os.stat(channel.data_file).st_size
-            # interleaved values/timestamps at 8 bytes each
             nsamples  = num_bytes / 8
             try:
                 # channel-specific sample size
@@ -119,7 +115,7 @@ def number_samples_test(task, expected):
 
 def bin_test(task, result_files):
     for channel in task.channels:
-        inferred_rate_test(channel.rate, channel.data_file, ftype=channel.type)
+        inferred_rate_test(channel)
 
 # ------------------- methods for global tests -------------------
 
@@ -181,7 +177,7 @@ def channels_test(task, ts_test):
     result_files = glob.glob('*ts.bin')
     assert len(task.channels) == len(result_files)
 
-    # bin_test(task, result_files)
+    bin_test(task, result_files)
 
     # cleanup
     [os.remove(f) for f in result_files]

--- a/processor/edf_processor/edf.py
+++ b/processor/edf_processor/edf.py
@@ -39,7 +39,7 @@ class EdfReader:
             self.start_date = f.read(8).strip().decode('utf-8', 'ignore')
             self.start_time = f.read(8).strip().decode('utf-8', 'ignore')
             self.nb_bytes = int(f.read(8))
-            self.reserved = f.read(44).strip()
+            self.reserved = f.read(44).strip().strip().decode('utf-8', 'ignore')
             self.nb_data_rec = int(f.read(8))
             self.duration = float(f.read(8))
             self.nb_signal = int(f.read(4))

--- a/processor/edf_processor/edf.py
+++ b/processor/edf_processor/edf.py
@@ -99,8 +99,7 @@ class EdfReader:
     def get_start_datetime(self):
         day, month, year = map(int, self.start_date.split("."))
         hour, minute, second = map(int, self.start_time.split("."))
-        year = year + 1900 if year < 85 else year + 2000
-
+        year = year + 2000 if year < 85 else year + 1900
         return datetime(year, month, day, hour, minute, second)
 
     def get_timestamps(self, index, signal_number, start_time) :

--- a/processor/edf_processor/edf.py
+++ b/processor/edf_processor/edf.py
@@ -1,4 +1,3 @@
-import sys
 import struct
 import re
 import numpy as np
@@ -9,7 +8,7 @@ SECOND_TO_USECOND = 1000000
 def twos_comp(val, bits):
     """Compute the 2's complement of int value val."""
     if (val & (1 << (bits - 1))) != 0:  # If sign bit is set, e.g., 8bit: 128-255
-        val = val - (1 << bits)         # Compute negative value
+        val -= (1 << bits)              # Compute negative value
     return val                          # Return positive value as is
 
 def transform_value(val, phys_min, phys_max, dig_min, dig_max, bits):
@@ -98,16 +97,10 @@ class EdfReader:
         return self.phy_dim[i]
 
     def get_start_datetime(self):
-        split_start_date = self.start_date.split(".")
-        split_start_time = self.start_time.split(".")
-        year = int(split_start_date[2]) + 1900
-        if (year < 1985):
-            year = year + 100
-        month = int(split_start_date[1])
-        day = int(split_start_date[0])
-        hour = int(split_start_time[0])
-        minute = int(split_start_time[1])
-        second = int(split_start_time[2])
+        day, month, year = map(int, self.start_date.split("."))
+        hour, minute, second = map(int, self.start_time.split("."))
+        year = year + 1900 if year < 85 else year + 2000
+
         return datetime(year, month, day, hour, minute, second)
 
     def get_timestamps(self, index, signal_number, start_time) :
@@ -117,7 +110,7 @@ class EdfReader:
         return np.linspace(start_time_record, end_time_record, num=self.get_nr_samples(signal_number), endpoint=False) 
   
     def is_discontiguous(self):
-        return (self.reserved == "EDF+D")
+        return self.reserved == "EDF+D"
 
     def get_duration(self):
         return self.duration

--- a/processor/edf_processor/edf.py
+++ b/processor/edf_processor/edf.py
@@ -74,16 +74,16 @@ class EdfReader:
                         self.data_signal[x] = np.append(self.data_signal[x], [
                             transform_value(struct.unpack('<H', z)[0], self.phy_min[x], self.phy_max[x], self.dig_min[x],
                                             self.dig_max[x], 16) for z in segment])
-    
+
     def get_n_samples(self):
         return [x * self.nb_data_rec for x in self.nr_samples] 
 
     def get_signal_labels(self):
         return self.labels
-   
+
     def get_record_start_time(self, i):
         return self.rec_start_time[i]
-    
+
     def get_number_of_data_records(self):
         return self.nb_data_rec
 

--- a/processor/edf_processor/processor.py
+++ b/processor/edf_processor/processor.py
@@ -1,4 +1,5 @@
 import traceback
+import numpy as np
 from base_processor.timeseries import BaseTimeSeriesProcessor
 from base_processor.timeseries.base import chunks
 import base_processor.timeseries.utils as utils
@@ -12,54 +13,49 @@ class EdfProcessor(BaseTimeSeriesProcessor):
         try:
             with EdfReader(file_path) as edf_file:
                 n_samples = edf_file.get_n_samples()
+                start_time = utils.usecs_since_epoch(edf_file.get_start_datetime())
 
-                for i, signal_name in enumerate(edf_file.get_signal_labels()):
+                for signal_number, signal_name in enumerate(edf_file.get_signal_labels()):
                     if signal_name == 'EDF Annotations':
                         continue
 
-                    sample_rate = edf_file.get_sample_frequency(i)
-                    unit = edf_file.get_physical_dimension(i)
+                    sample_rate = edf_file.get_sample_frequency(signal_number)
+                    unit = edf_file.get_physical_dimension(signal_number)
+                    nb_samples_per_record = edf_file.get_nr_samples(signal_number)
 
-                    if edf_file.is_discontiguous():
-                        for index in range(edf_file.get_number_of_data_records()):
-                            record_timestamps = edf_file.get_timestamps(index, i, utils.usecs_since_epoch(edf_file.get_start_datetime()))
+                    channel = self.get_or_create_channel(
+                        name=str(signal_name).strip(),
+                        unit=str(unit),
+                        rate=sample_rate,
+                        type='continuous'
+                    )
 
-                            nb_samples_per_record = edf_file.get_nr_samples(i)
+                    timestamps = []
+                    values = []
+                    for index in range(edf_file.get_number_of_data_records()):
+                            vals = edf_file.read_signal(signal_number, index * nb_samples_per_record, (index + 1) * nb_samples_per_record)
+                            # if the EDF file is_discontiguous then it includes timestamp per values for each signal/record
+                            if edf_file.is_discontiguous():
+                                ts = edf_file.get_timestamps(index, signal_number, start_time)
+                            # otherwise the data is contiguous and we need to create a set of corresponding timestamps
+                            # per value using the sampling rate and start / end times
+                            else:
+                                nsamples = n_samples[signal_number]
+                                length = (n_samples[signal_number] - 1) / sample_rate
+                                end_time = int(start_time + length * 1e6)
+                                # setting the chunk_size = nsamples should yield exactly one chunk
+                                chunk = next(chunks(start_time, end_time, nsamples, nsamples))
+                                ts = chunk.timestamps
 
-                            channel = self.get_or_create_channel(
-                                name=str(signal_name).strip(),
-                                unit=str(unit),
-                                rate=sample_rate,
-                                type='continuous'
-                            )
+                            timestamps.append(ts[:len(vals)])
+                            values.append(vals)
 
-                            vals = edf_file.read_signal(i, index * nb_samples_per_record, (index + 1) * nb_samples_per_record)
+                    self.write_channel_data(
+                        channel=channel,
+                        timestamps=np.concatenate(timestamps),
+                        values=np.concatenate(values)
+                    )
 
-                            self.write_channel_data(
-                                channel=channel,
-                                timestamps=record_timestamps[:len(vals)],
-                                values=vals
-                            )
-                    else:
-                        start_time = utils.usecs_since_epoch(edf_file.get_start_datetime())
-                        length = (n_samples[i] - 1) / sample_rate
-                        end_time = int(start_time + length * 1e6)
-
-                        for chunk in chunks(start_time, end_time, n_samples[i]):
-                            channel = self.get_or_create_channel(
-                                name=str(signal_name).strip(),
-                                unit=str(unit),
-                                rate=sample_rate,
-                                type='continuous'
-                            )
-
-                            vals = edf_file.read_signal(i, chunk.start_index, chunk.end_index)
-
-                            self.write_channel_data(
-                                channel=channel,
-                                timestamps=chunk.timestamps[:len(vals)],
-                                values=vals
-                            )
         except Exception as e:
             print(traceback.format_exc())
 

--- a/processor/edf_processor/processor.py
+++ b/processor/edf_processor/processor.py
@@ -48,7 +48,7 @@ class EdfProcessor(BaseTimeSeriesProcessor):
                     else:
                         nsamples = n_samples[signal_number]
                         length = (n_samples[signal_number] - 1) / sample_rate
-                        end_time = int(start_time + length * 1e6)
+                        end_time = int(start_time + utils.secs_to_usecs(length))
 
                         # setting the chunk_size = nsamples should yield exactly one chunk
                         chunk = next(chunks(start_time, end_time, nsamples, nsamples))

--- a/tests/params.py
+++ b/tests/params.py
@@ -9,7 +9,7 @@ params_global = [
         name      = 'test',
         nchannels = 11,
         nsamples  = 120000,
-        result    = 'pass', 
+        result    = 'pass',
         rate      = 200,
         inputs    = {
             'file': '/data/input/test.edf'
@@ -19,7 +19,7 @@ params_global = [
         name      = 'test2',
         nchannels = 43,
         nsamples  = 497400,
-        result    = 'pass', 
+        result    = 'pass',
         rate      = 200,
         inputs    = {
             'file': '/data/input/103-002_EEG_01_17_2019.edf'
@@ -29,7 +29,7 @@ params_global = [
         template  = True,
         nchannels = 2,
         nsamples  = 12000,
-        result    = 'pass', 
+        result    = 'pass',
         rate      = 800,
         inputs    = {
             'file': '/data/input/sin_wave.edf'


### PR DESCRIPTION
### Description
**ClickUp Ticket:** [86889nbwd](https://app.clickup.com/t/86889nbwd)

Refactored the EDF processor to conform to the new output format: channel data files containing only sample data with continuous chunk start times added to the channel metadata JSON file.